### PR TITLE
Fix a bunch of compiler warnings

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,13 +1,14 @@
 #![allow(non_snake_case)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
 
-use ::{Error, Result};
+use ::Result;
 use ast::*;
 use instruction::*;
-use std::borrow::BorrowMut;
 use std::collections::HashMap;
 use std::f64;
 use std::fmt::{Debug, Error as FmtError, Formatter};
-use std::mem::{replace, swap};
+use std::mem::swap;
 use std::rc::Rc;
 use std::result::Result as StdResult;
 use value::*;
@@ -279,9 +280,9 @@ impl Instructions {
 
 impl Debug for Instructions {
     fn fmt(&self, f: &mut Formatter) -> StdResult<(), FmtError> {
-        writeln!(f, "PC: <{}>", self.pc);
+        writeln!(f, "PC: <{}>", self.pc)?;
         for (i, inst) in self.insts.iter().enumerate() {
-            writeln!(f, "<{:04}:L{:04}> {}", i, self.lines[i], to_string(*inst));
+            writeln!(f, "<{:04}:L{:04}> {}", i, self.lines[i], to_string(*inst))?;
         }
         Ok(())
     }
@@ -659,11 +660,11 @@ impl<'p> Compiler<'p> {
     }
 
     fn load_rk(&mut self, reg: &mut usize, expr: &ExprNode, cnst: Rc<Value>) -> i32 {
-        let mut cindex = self.const_index(cnst) as i32;
+        let cindex = self.const_index(cnst) as i32;
         if cindex < opMaxIndexRk {
             rk_ask(cindex)
         } else {
-            let mut ret = *reg;
+            let ret = *reg;
             *reg += 1;
             self.code.add_ABx(OP_LOADK, ret as i32, cindex, start_line(expr));
             ret as i32
@@ -838,7 +839,7 @@ impl<'p> Compiler<'p> {
         self.code.add_ASBx(OP_JMP, 0, jumplabel, line);
     }
 
-    fn compile_binary_rel_expr(&mut self, mut reg: usize,
+    fn compile_binary_rel_expr(&mut self, reg: usize,
                                opr: BinaryOpr, lhs: &ExprNode, rhs: &ExprNode,
                                expr_ctx: &ExprContext, line: u32) {
         let a = expr_ctx.savereg(reg);
@@ -945,7 +946,7 @@ impl<'p> Compiler<'p> {
         }
     }
 
-    fn compile_binary_log_expr(&mut self, mut reg: usize,
+    fn compile_binary_log_expr(&mut self, reg: usize,
                                opr: BinaryOpr, lhs: &ExprNode, rhs: &ExprNode,
                                expr_ctx: &ExprContext, line: u32) {
         let a = expr_ctx.savereg(reg);
@@ -1022,7 +1023,7 @@ impl<'p> Compiler<'p> {
                     self.code.pop();
                     pc -= 1;
                 }
-                self.code.add_ABC(OP_CONCAT, a as i32, basereg as i32, (basereg as i32 + crange), start_line(expr));
+                self.code.add_ABC(OP_CONCAT, a as i32, basereg as i32, basereg as i32 + crange, start_line(expr));
             }
             Expr::BinaryOp(ref opr, ref lhs, ref rhs)
             if opr == &BinaryOpr::Eq ||
@@ -1316,7 +1317,7 @@ impl<'p> Compiler<'p> {
             }
 
             // regular assignment
-            let mut ac = &mut acs[namesassigned];
+            let ac = &mut acs[namesassigned];
             let mut nilexprs: Vec<ExprNode> = vec![];
             let expr = if namesassigned >= lenexprs {
                 let mut expr = ExprNode::new(Expr::Nil, lhs[namesassigned].lineinfo());
@@ -1873,7 +1874,7 @@ impl<'p> Compiler<'p> {
 
         self.code.add_ABC(OP_RETURN, 0, 1, 0, endline);
         self.end_scope();
-        let mut codestore = Instructions::new();
+        let codestore = Instructions::new();
 
         self.proto.code = self.code.list();
         self.proto.debug_pos = self.code.line_list();

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1,7 +1,5 @@
 #![allow(non_snake_case)]
-#![allow(non_snake_case_globals)]
-
-use std::fmt::Display;
+#![allow(non_upper_case_globals)]
 
 pub const INVALID_INSTRUCTION: u32 = 0xFFFFFFFF;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 extern crate bytes;
 
 pub mod state;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,8 @@
-use ::{Error, NO_JUMP, Result};
+#![allow(unused_variables)]
+
+use ::{Error, Result};
 use ast::*;
 use scanner::{Scanner, Token};
-use state::State;
 use std::io::{BufReader, Read};
 use std::mem;
 
@@ -193,7 +194,7 @@ impl<R: Read> Parser<R> {
         }
         let line = self.line_number;
         // is not last statement
-        let mut stmt = match self.token {
+        let stmt = match self.token {
             Token::If => self.ifstat()?,
             Token::While => self.whilestat()?,
             Token::Do => {
@@ -268,7 +269,7 @@ impl<R: Read> Parser<R> {
             }
         }
         self.check_next(Token::Char('}'))?;
-        let mut exprnode = ExprNode::new(Expr::Table(fields), (line, self.prev_number));
+        let exprnode = ExprNode::new(Expr::Table(fields), (line, self.prev_number));
         Ok(exprnode)
     }
 
@@ -318,7 +319,7 @@ impl<R: Read> Parser<R> {
         let block = self.block()?;
         self.check_next(Token::End)?;
 
-        let mut exprnode = ExprNode::new(Expr::Function(parlist, block), (line, self.prev_number));
+        let exprnode = ExprNode::new(Expr::Function(parlist, block), (line, self.prev_number));
         Ok(exprnode)
     }
 
@@ -335,7 +336,7 @@ impl<R: Read> Parser<R> {
     /// ```
     fn prefixexp(&mut self) -> Result<ExprNode> {
         let line = self.line_number;
-        let mut expr = match self.token {
+        let expr = match self.token {
             Token::Ident(ref s) => {
                 let expr = ExprNode::new(Expr::Ident(s.clone()), (line, line));
                 expr
@@ -451,7 +452,7 @@ impl<R: Read> Parser<R> {
     /// ```
     fn simple_expr(&mut self) -> Result<ExprNode> {
         let lineinfo = (self.line_number, self.line_number);
-        let mut node = match self.token {
+        let node = match self.token {
             Token::True => ExprNode::new(Expr::True, lineinfo),
             Token::False => ExprNode::new(Expr::False, lineinfo),
             Token::Nil => ExprNode::new(Expr::Nil, lineinfo),
@@ -496,9 +497,9 @@ impl<R: Read> Parser<R> {
     fn expression(&mut self) -> Result<ExprNode> { Ok(self.sub_expression(0)?.0) }
 
     fn test_then_block(&mut self) -> Result<IfThenElse> {
-        let mut jump_false = 0;
+        let jump_false = 0;
         self.next()?;
-        let mut condition = self.expression()?;
+        let condition = self.expression()?;
         self.check_next(Token::Then)?;
         let then = self.block()?;
         Ok(IfThenElse::new(condition, then, vec![]))
@@ -512,7 +513,7 @@ impl<R: Read> Parser<R> {
         let mut elseifs: Vec<(IfThenElse, (u32, u32))> = vec![];
         while self.token == Token::Elseif {
             let line = self.line_number;
-            let mut elseif = self.test_then_block()?;
+            let elseif = self.test_then_block()?;
             elseifs.push((elseif, (line, self.prev_number)));
         }
 
@@ -561,7 +562,7 @@ impl<R: Read> Parser<R> {
         let limit = self.expression()?;
         // step optional
         let line = self.line_number;
-        let mut step = if self.testnext(&Token::Char(','))? {
+        let step = if self.testnext(&Token::Char(','))? {
             self.expression()?
         } else {
             ExprNode::new(Expr::Number(1.0), (line, self.prev_number))
@@ -607,7 +608,7 @@ impl<R: Read> Parser<R> {
             Token::Char(',') | Token::In => self.forlist(varname)?,
             _ => return Err(Error::SyntaxError("= or in expected".to_string()))
         };
-        self.check_match(Token::End, Token::For, line);
+        self.check_match(Token::End, Token::For, line)?;
         Ok(stmt)
     }
 
@@ -675,7 +676,7 @@ impl<R: Read> Parser<R> {
 
     fn localfunc(&mut self) -> Result<Stmt> {
         let line = self.line_number;
-        let mut name = if let Token::Ident(ref s) = self.token {
+        let name = if let Token::Ident(ref s) = self.token {
             s.clone()
         } else {
             return Err(self.unexpected(&self.token));

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,9 +1,7 @@
 use ::{Error, Result};
 use bytes::{BufMut, BytesMut};
-use state::State;
 use std::f64;
 use std::io::{BufRead, BufReader, Read};
-use std::mem;
 use std::u8;
 
 /// END_OF_STREAM indicates that scanner has reach the end of stream.
@@ -235,7 +233,6 @@ impl<R: Read> Scanner<R> {
                 }
             }
         }
-        unreachable!()
     }
 
     fn advance(&mut self) {
@@ -350,7 +347,6 @@ impl<R: Read> Scanner<R> {
                 }
             }
         }
-        unreachable!()
     }
 
     fn read_string(&mut self) -> Result<Token> {
@@ -363,17 +359,17 @@ impl<R: Read> Scanner<R> {
                     self.advance();
                     let current = self.current;
                     match current {
-                        /// Escape charactors
-                        /// \a   U+0007 alert or bell
-                        /// \b   U+0008 backspace
-                        /// \f   U+000C form feed
-                        /// \n   U+000A line feed or newline
-                        /// \r   U+000D carriage return
-                        /// \t   U+0009 horizontal tab
-                        /// \v   U+000b vertical tab
-                        /// \\   U+005c backslash
-                        /// \'   U+0027 single quote  (valid escape only within rune literals)
-                        /// \"   U+0022 double quote  (valid escape only within string literals)
+                        // Escape charactors
+                        // \a   U+0007 alert or bell
+                        // \b   U+0008 backspace
+                        // \f   U+000C form feed
+                        // \n   U+000A line feed or newline
+                        // \r   U+000D carriage return
+                        // \t   U+0009 horizontal tab
+                        // \v   U+000b vertical tab
+                        // \\   U+005c backslash
+                        // \'   U+0027 single quote  (valid escape only within rune literals)
+                        // \"   U+0022 double quote  (valid escape only within string literals)
                         'a' => self.advance_and_save('\u{0007}'),
                         'b' => self.advance_and_save('\u{0008}'),
                         'f' => self.advance_and_save('\u{000C}'),
@@ -470,7 +466,7 @@ impl<R: Read> Scanner<R> {
             if i > 2 || !is_decimal(c) {
                 break;
             }
-            let mut cvalue = c as u32;
+            let cvalue = c as u32;
             r = r * 10 + (cvalue - ('0' as u32));
             self.advance();
             c = self.current;
@@ -512,7 +508,7 @@ impl<R: Read> Scanner<R> {
             self.buffer.clear();
 
             let mut exponent: isize = 0;
-            let (mut fraction, mut latest_char, mut count) = self.read_hexadecimal(0.0);
+            let (mut fraction, mut latest_char, count) = self.read_hexadecimal(0.0);
 
             if latest_char == '.' {
                 self.advance();

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,10 +1,9 @@
+#![allow(unused_variables)]
+
 use {parser, undump};
-use ::{Error, Result};
+use ::Result;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Cursor, Read};
-use std::io;
-use std::result;
-use std::string;
 use compiler;
 
 /// A State is an opaque structure representing per thread Lua state.
@@ -27,13 +26,13 @@ impl State {
 
     pub fn load_file(&mut self, path: &str) -> Result<()> {
         let f = File::open(path)?;
-        let mut reader = BufReader::new(f);
+        let reader = BufReader::new(f);
         self.load(reader, path)
     }
 
     pub fn load_string(&mut self, s: &str) -> Result<()> {
         let cursor = Cursor::new(s.as_bytes());
-        let mut reader = BufReader::new(cursor);
+        let reader = BufReader::new(cursor);
         self.load(reader, "<string>")
     }
 

--- a/src/undump.rs
+++ b/src/undump.rs
@@ -1,6 +1,8 @@
-use ::{Error, Result};
+#![allow(unused_variables)]
+
+use ::Result;
 use compiler::FunctionProto;
-use std::io::{BufRead, BufReader, Read};
+use std::io::{BufReader, Read};
 
 pub fn undump<T: Read>(reader: BufReader<T>) -> Result<Box<FunctionProto>> {
     unimplemented!()

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,3 +1,5 @@
+#[allow(dead_code)]
+
 #[derive(Debug, PartialEq)]
 pub enum Value {
     Nil,


### PR DESCRIPTION
- added some ignore directives
- return errors where they weren't being returned
- remove a bunch of extra imports and `mut`

I left a few warnings that I thought were indicative of a potential error. On my machine, I get 4 warnings, though I've ignored quite a few.

It's *very* hard to see the compile errors with the sheer number of warnings, which is why I'm making this PR.